### PR TITLE
Fix Fastweb Energia supply selection (CTA renamed to "Accedi")

### DIFF
--- a/bolletta_sync/providers/fastweb_energia.py
+++ b/bolletta_sync/providers/fastweb_energia.py
@@ -42,11 +42,11 @@ class FastwebEnergia(BaseProvider):
 
         try:
             await self.page.get_by_text(supply_code, exact=True).click()
-            avanti = self.page.get_by_role("link", name="Avanti")
+            accedi = self.page.get_by_role("link", name="Accedi")
             async with self.page.expect_navigation():
-                await avanti.click()
-        except Exception:
-            raise Exception(f"invalid supply code: {supply_code}")
+                await accedi.click()
+        except Exception as e:
+            raise Exception(f"invalid supply code: {supply_code} ({e})") from e
 
     async def get_invoices(self, start_date: date, end_date: date) -> list[Invoice]:
         invoices: list[Invoice] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bolletta-sync"
-version = "1.0.0"
+version = "1.0.1"
 description = ""
 authors = [
     {name = "Gabriele Sorci", email = "gabrielesorci.25@gmail.com"}


### PR DESCRIPTION
## Problem

The `fastweb_energia` sync hung on the `scelta-fornitura` page.

Fastweb redesigned that page (the `multinew` variant) and renamed the CTA from **"Avanti"** to **"Accedi"**:

```html
<a id="handler_..." class="button is-primary no-icon" href="#">Accedi</a>
```

The `get_by_role("link", name="Avanti")` locator no longer matched anything, so the run waited for the Playwright timeout and the exception was then rewritten as `invalid supply code: <pod>` — a misleading message that hid the real cause.

## Verification

Reproduced against the live portal, on the supply-choice page:

- links present: `['ACCEDI', 'Insieme, siamo futuro', 'Informativa Privacy', ...]`
- `count 'Avanti': 0` — `count 'Accedi': 1`
- clicking the POD/PDR code already worked (the radio was correctly selected)

After the fix, `FastwebEnergia.get_invoices` against both configured supplies:

- electricity POD → 24 invoices in the list, 7 within the 2026 range, PDF downloaded successfully (`%PDF`, 191 KB)
- gas PDR → the portal returns `HTTP 200`, `errorCode: 0`, `invoiceList: []` (no invoices on Fastweb's side, not a sync error)

## Changes

- `_select_supply`: CTA locator updated to "Accedi"
- the original error is chained into the message (`from e`), so a future change to the page is diagnosable from the logs instead of surfacing as an invalid supply code
- version bump `1.0.0` → `1.0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)