### PR TITLE
Add retry for failed providers on the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Bolletta Sync is a Python-based web service designed to automate the synchroniza
 - **Google Tasks Integration**: Creates tasks for invoice payment deadlines with the due date and amount.
 - **REST API**: Simple FastAPI interface to trigger synchronization and check status.
 - **Sync Persistence**: Saves the result of every synchronization to `data/last_sync.json` for easy auditing and status tracking.
+- **Retry from the Dashboard**: When a provider fails, a **Retry failed** button on the dashboard re-runs the sync for the failed providers only, over the same date range.
 
 ## Prerequisites
 
@@ -128,10 +129,10 @@ With an empty body, all providers are synced for the last `SYNC_DAYS_OFFSET` day
 
 If `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` are set, all API endpoints require authentication via session cookie (browser) or HTTP Basic Auth (API clients / Swagger).
 
-- **GET `/`**: Check API status, version, Google authentication state, and the details of the last synchronization.
+- **GET `/`**: Check API status, version, Google authentication state, whether a sync is currently running (`sync_in_progress`), and the details of the last synchronization.
 - **GET `/providers`**: List supported providers.
 - **POST `/auth/token`**: Exchange a Google authorization code for a token. Submitted by the dashboard form as `application/x-www-form-urlencoded` (field `code`); redirects back to `/` on success.
-- **POST `/sync`**: Trigger a synchronization process in the background. Returns a 200 status code once the process has been taken over by the server.
+- **POST `/sync`**: Trigger a synchronization process in the background. Returns a 200 status code once the process has been taken over by the server, or **409** if a sync is already running — only one sync may run at a time.
 
   **Request Body Example**:
   ```json
@@ -142,6 +143,25 @@ If `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` are set, all API endpoints re
   }
   ```
   *If `providers` is omitted, all providers will be synced. `start_date` defaults to `SYNC_DAYS_OFFSET` days ago (default 10), and `end_date` defaults to today.*
+
+### Retrying a Failed Sync
+
+When the last run reports at least one provider in error, the dashboard shows a **Retry failed** button next to the sync status. It re-runs the sync for the failed providers only, reusing the date range of the previous run, and reloads the page automatically until the sync finishes.
+
+The report in `data/last_sync.json` is **merged** with the previous one instead of being replaced, so providers that are not part of a retry keep their last known result. Each provider entry carries its own `date`, and the top-level `start_date` / `end_date` record the range of the most recent run:
+
+```json
+{
+  "date": "2025-01-10T09:15:00.000000",
+  "start_date": "2024-12-31",
+  "end_date": "2025-01-10",
+  "status": "error",
+  "results": {
+    "fastweb": { "status": "success", "count": 1, "attempts": 1, "date": "2025-01-10T09:02:00.000000", "invoices": [] },
+    "eni": { "status": "error", "attempts": 4, "date": "2025-01-10T09:15:00.000000", "error": "..." }
+  }
+}
+```
 
 ## Project Structure
 

--- a/bolletta_sync/main.py
+++ b/bolletta_sync/main.py
@@ -1,13 +1,12 @@
 import hashlib
 import hmac
-import json
 import logging
 import os
 import secrets
 import importlib.metadata
 from contextlib import asynccontextmanager
 from datetime import date, timedelta
-from typing import Any, List, Optional
+from typing import List, Optional, Tuple
 
 from fastapi import FastAPI, Form, Request, HTTPException, Depends, BackgroundTasks
 from fastapi.responses import JSONResponse, RedirectResponse
@@ -23,7 +22,7 @@ from bolletta_sync.sync import (
     get_google_credentials,
     get_google_flow,
     google_token_file,
-    last_sync_file,
+    read_last_sync,
 )
 
 load_dotenv()
@@ -164,7 +163,12 @@ class SyncResponse(BaseModel):
 
 
 @app.get("/", dependencies=[Depends(get_basic_auth)])
-async def root(request: Request, auth_error: bool = False):
+async def root(
+    request: Request,
+    auth_error: bool = False,
+    sync_started: bool = False,
+    sync_busy: bool = False,
+):
     """
     Return the API status and version.
     """
@@ -181,13 +185,7 @@ async def root(request: Request, auth_error: bool = False):
         except Exception as e:
             logger.warning(f"Could not generate auth URL: {e}")
 
-    last_sync = None
-    if os.path.exists(last_sync_file):
-        try:
-            with open(last_sync_file, "r") as f:
-                last_sync = json.load(f)
-        except Exception as e:
-            logger.error(f"Failed to read last sync file: {e}")
+    last_sync = read_last_sync() or None
 
     # Handle HTML requests for the UI
     accept = request.headers.get("accept", "")
@@ -204,6 +202,9 @@ async def root(request: Request, auth_error: bool = False):
                 "version": app.version,
                 "security_enabled": security_enabled,
                 "auth_error": auth_error,
+                "sync_started": sync_started,
+                "sync_busy": sync_busy,
+                "sync_in_progress": is_sync_running(),
             },
         )
 
@@ -211,6 +212,7 @@ async def root(request: Request, auth_error: bool = False):
         "message": "Bolletta Sync API is running",
         "version": app.version,
         "authenticated": authenticated,
+        "sync_in_progress": is_sync_running(),
         "last_sync": last_sync,
     }
 
@@ -284,18 +286,45 @@ async def get_providers():
     return {"providers": [p.value for p in Provider]}
 
 
+# Only one sync may run at a time: Playwright and the provider logins are not reentrant.
+_sync_running = False
+
+
+def is_sync_running() -> bool:
+    """Return True while a sync is running."""
+    return _sync_running
+
+
+def try_start_sync() -> bool:
+    """
+    Claim the sync slot. Returns False if a sync is already running.
+    There is no await between the check and the assignment, so this is atomic
+    on the asyncio event loop.
+    """
+    global _sync_running
+    if _sync_running:
+        return False
+    _sync_running = True
+    return True
+
+
+def _release_sync() -> None:
+    global _sync_running
+    _sync_running = False
+
+
 async def run_sync_task(
     providers: List[Provider],
     start_date: date,
     end_date: date,
 ):
-    """Background task to run the sync process."""
-    google_credentials = await get_google_credentials()
-    if not google_credentials:
-        logger.error("Background sync failed: Not authenticated with Google")
-        return
-
+    """Background task to run the sync process. Releases the sync slot when done."""
     try:
+        google_credentials = await get_google_credentials()
+        if not google_credentials:
+            logger.error("Background sync failed: Not authenticated with Google")
+            return
+
         await Sync(
             google_credentials=google_credentials,
             providers=providers,
@@ -304,6 +333,8 @@ async def run_sync_task(
         logger.info(f"Background sync completed for {len(providers)} providers")
     except Exception as e:
         logger.error(f"Background sync failed: {e}")
+    finally:
+        _release_sync()
 
 
 @app.post("/sync", response_model=SyncResponse, dependencies=[Depends(get_basic_auth)])
@@ -317,6 +348,9 @@ async def trigger_sync(request: SyncRequest, background_tasks: BackgroundTasks):
     if not google_credentials:
         raise HTTPException(status_code=401, detail="Not authenticated with Google. Please visit /auth/login")
 
+    if not try_start_sync():
+        raise HTTPException(status_code=409, detail="A sync is already running")
+
     # Add to background tasks
     background_tasks.add_task(
         run_sync_task,
@@ -329,3 +363,59 @@ async def trigger_sync(request: SyncRequest, background_tasks: BackgroundTasks):
         message=f"Sync process started for {len(request.providers)} providers from {request.start_date} to {request.end_date}",
         status="accepted",
     )
+
+
+def _failed_providers(last_sync: dict) -> List[Provider]:
+    """Return the providers that failed in the given sync report."""
+    providers = []
+    for name, result in last_sync.get("results", {}).items():
+        if result.get("status") != "error":
+            continue
+        try:
+            providers.append(Provider(name))
+        except ValueError:
+            logger.warning(f"Ignoring unknown provider in last sync report: {name}")
+    return providers
+
+
+def _last_sync_date_range(last_sync: dict) -> Tuple[date, date]:
+    """
+    Return the date range of the given sync report, falling back to the same
+    defaults as SyncRequest when the report predates those fields.
+    """
+    try:
+        return (
+            date.fromisoformat(last_sync["start_date"]),
+            date.fromisoformat(last_sync["end_date"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return date.today() - timedelta(days=SYNC_DAYS_OFFSET), date.today()
+
+
+@app.post("/sync/retry", include_in_schema=False, dependencies=[Depends(get_basic_auth)])
+async def retry_failed_sync(background_tasks: BackgroundTasks):
+    """
+    Re-run the sync for the providers that failed in the last run, over the same
+    date range. Submitted by the dashboard form; always redirects back to /.
+    """
+    last_sync = read_last_sync()
+    providers = _failed_providers(last_sync)
+    if not providers:
+        return RedirectResponse(url="/", status_code=303)
+
+    google_credentials = await get_google_credentials()
+    if not google_credentials:
+        logger.error("Retry rejected: Not authenticated with Google")
+        return RedirectResponse(url="/", status_code=303)
+
+    if not try_start_sync():
+        return RedirectResponse(url="/?sync_busy=1", status_code=303)
+
+    start_date, end_date = _last_sync_date_range(last_sync)
+    background_tasks.add_task(run_sync_task, providers, start_date, end_date)
+
+    logger.info(
+        f"Retry started for {[p.value for p in providers]} from {start_date} to {end_date}"
+    )
+
+    return RedirectResponse(url="/?sync_started=1", status_code=303)

--- a/bolletta_sync/static/styles.css
+++ b/bolletta_sync/static/styles.css
@@ -254,7 +254,7 @@ a {
   transition: background-color 0.15s;
 }
 
-.button:hover {
+.button:hover:not(:disabled) {
   background: var(--color-primary-hover);
 }
 
@@ -262,6 +262,36 @@ a {
   width: 100%;
   padding: 0.5rem 1rem;
   font-weight: 600;
+}
+
+.button--sm {
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.button:disabled {
+  background: var(--color-text-subtle);
+  cursor: default;
+}
+
+/* Notices */
+.notice {
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
+}
+
+.notice--info {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.notice--warning {
+  background: var(--color-warning-bg);
+  border: 1px solid var(--color-warning-border);
+  color: var(--color-warning-text);
 }
 
 .form-message {
@@ -286,6 +316,12 @@ a {
   font-weight: 700;
   color: var(--color-text);
   margin: 0;
+}
+
+.section-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .badge {
@@ -337,6 +373,10 @@ a {
   margin: 0 0 0.25rem;
 }
 
+.meta-box__label--spaced {
+  margin-top: 0.75rem;
+}
+
 .meta-box__value {
   font-size: 0.875rem;
   font-family: var(--font-mono);
@@ -385,6 +425,13 @@ a {
   padding: 0.75rem;
   border-bottom: 1px solid var(--color-border);
   color: var(--color-text-muted);
+}
+
+.table td.timestamp {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--color-text-subtle);
+  white-space: nowrap;
 }
 
 .table td.provider {

--- a/bolletta_sync/sync.py
+++ b/bolletta_sync/sync.py
@@ -26,6 +26,22 @@ google_token_file = "./data/google_token.json"
 last_sync_file = "./data/last_sync.json"
 
 
+def read_last_sync() -> Dict[str, Any]:
+    """
+    Loads the last sync report from the data folder.
+    Returns an empty dict if the file is missing or unreadable.
+    """
+    if not os.path.exists(last_sync_file):
+        return {}
+
+    try:
+        with open(last_sync_file, "r") as f:
+            return json.load(f)
+    except Exception as e:
+        logger.error(f"Failed to read last sync file: {e}")
+        return {}
+
+
 class Provider(Enum):
     """Provider enum."""
 
@@ -162,6 +178,36 @@ class Sync:
         finally:
             await page.close()
 
+    def _save_last_sync(self, results: Dict[str, Any]) -> None:
+        """
+        Persist the run results, merged with the previous report so that providers
+        not included in this run (e.g. a retry limited to the failed ones) stay visible.
+        """
+        try:
+            merged_results = {**read_last_sync().get("results", {}), **results}
+
+            # Overall status is success only if all individual results are success
+            overall_status = "success"
+            if not merged_results:
+                overall_status = "empty"
+            elif any(res.get("status") == "error" for res in merged_results.values()):
+                overall_status = "error"
+
+            with open(last_sync_file, "w") as f:
+                json.dump(
+                    {
+                        "date": datetime.now().isoformat(),
+                        "start_date": self._date_range[0].isoformat(),
+                        "end_date": self._date_range[1].isoformat(),
+                        "status": overall_status,
+                        "results": merged_results,
+                    },
+                    f,
+                    indent=4,
+                )
+        except Exception as e:
+            logger.error(f"Failed to save last sync result: {e}")
+
     async def run(self, headless: bool = True) -> Dict[str, Any]:
         """Run syncs invoices for the given providers and returns a summary of the results."""
         results = {}
@@ -178,37 +224,19 @@ class Sync:
                         "status": "success",
                         "count": len(invoices),
                         "attempts": attempts,
+                        "date": datetime.now().isoformat(),
                         "invoices": [invoice.model_dump(mode="json") for invoice in invoices],
                     }
                 except Exception as e:
                     results[provider.value] = {
                         "status": "error",
                         "attempts": self._max_retries + 1,
+                        "date": datetime.now().isoformat(),
                         "error": str(e),
                     }
 
             await browser.close()
 
-        # Persist result to data folder
-        try:
-            # Overall status is success only if all individual results are success
-            overall_status = "success"
-            if not results:
-                overall_status = "empty"
-            elif any(res.get("status") == "error" for res in results.values()):
-                overall_status = "error"
-
-            with open(last_sync_file, "w") as f:
-                json.dump(
-                    {
-                        "date": datetime.now().isoformat(),
-                        "status": overall_status,
-                        "results": results,
-                    },
-                    f,
-                    indent=4,
-                )
-        except Exception as e:
-            logger.error(f"Failed to save last sync result: {e}")
+        self._save_last_sync(results)
 
         return results

--- a/bolletta_sync/templates/index.html
+++ b/bolletta_sync/templates/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bolletta Sync Dashboard</title>
+    {% if sync_in_progress %}
+    <meta http-equiv="refresh" content="15" />
+    {% endif %}
     <link rel="icon" href="/static/logo.png" />
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
@@ -17,6 +20,18 @@
 
     <main class="container">
       <div class="card">
+        <!-- Sync Feedback Banners -->
+        {% if sync_started %}
+        <div class="notice notice--info">
+          Retry started in the background. This page refreshes automatically while
+          the sync is running.
+        </div>
+        {% elif sync_busy %}
+        <div class="notice notice--warning">
+          A sync is already running. Wait for it to finish before starting another one.
+        </div>
+        {% endif %}
+
         <!-- Header Status Section -->
         <div class="status-header">
           <div class="status-indicator">
@@ -92,19 +107,35 @@
         <!-- Sync Details Section -->
         <div class="section-header">
           <h3 class="section-title">Last Sync</h3>
-          {% if last_sync %}
-          <span
-            class="badge {% if last_sync.status == 'success' %}badge--success{% else %}badge--danger{% endif %}"
-          >
-            {{ last_sync.status | upper }}
-          </span>
-          {% endif %}
+          <div class="section-actions">
+            {% if last_sync %}
+            <span
+              class="badge {% if last_sync.status == 'success' %}badge--success{% else %}badge--danger{% endif %}"
+            >
+              {{ last_sync.status | upper }}
+            </span>
+            {% endif %} {% if sync_in_progress %}
+            <button type="button" class="button button--sm" disabled>
+              Sync in progress…
+            </button>
+            {% elif authenticated and last_sync and last_sync.status == 'error' %}
+            <form method="post" action="/sync/retry">
+              <button type="submit" class="button button--sm">Retry failed</button>
+            </form>
+            {% endif %}
+          </div>
         </div>
 
         {% if last_sync %}
         <div class="meta-box">
-          <p class="meta-box__label">Run Date</p>
+          <p class="meta-box__label">Last Run</p>
           <p class="meta-box__value">{{ last_sync.date }}</p>
+          {% if last_sync.start_date and last_sync.end_date %}
+          <p class="meta-box__label meta-box__label--spaced">Date Range</p>
+          <p class="meta-box__value">
+            {{ last_sync.start_date }} → {{ last_sync.end_date }}
+          </p>
+          {% endif %}
         </div>
 
         {% if last_sync.results %}
@@ -115,6 +146,7 @@
                 <th>Provider</th>
                 <th class="center">Invoices</th>
                 <th class="center">Attempts</th>
+                <th class="center">Last Run</th>
                 <th class="right">Status</th>
               </tr>
             </thead>
@@ -132,6 +164,9 @@
                     {{ data.attempts | default('-') }}
                   </span>
                 </td>
+                <td class="center timestamp">
+                  {{ (data.get('date') or last_sync.date or '')[:19] | replace('T', ' ') }}
+                </td>
                 <td class="right">
                   <span
                     class="badge {% if data.status == 'success' %}badge--success{% else %}badge--danger{% endif %}"
@@ -142,7 +177,7 @@
               </tr>
               {% if data.invoices %}
               <tr class="row-docs">
-                <td colspan="4">
+                <td colspan="5">
                   <div class="doc-list__label">Detected documents:</div>
                   <div class="doc-list__items">
                     {% for inv in data.invoices %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bolletta-sync"
-version = "1.0.1"
+version = "1.1.0"
 description = ""
 authors = [
     {name = "Gabriele Sorci", email = "gabrielesorci.25@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "bolletta-sync"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

The dashboard showed the last sync report read-only: recovering from a failed provider meant calling `POST /sync` by hand with an HTTP client.

This adds a **Retry failed** button next to the sync status that re-runs the sync for the failed providers only, reusing the date range of the previous run. The dashboard has no JavaScript, so it is a plain form POST to a new `/sync/retry` endpoint that redirects back to `/`.

## Merged sync report

For a partial retry to be useful, `data/last_sync.json` is now **merged** with the previous report instead of replacing it: providers that were not re-run keep their last known result, and the overall status only turns `success` once every known provider is fine. Each provider entry carries its own `date`, and the run's `start_date` / `end_date` are persisted so the retry can reuse them. Reports written before this change are still read correctly (the retry falls back to `SYNC_DAYS_OFFSET`).

## One sync at a time

Playwright and the provider logins are not reentrant, and a button makes concurrent runs easy to trigger. An in-memory lock now guards the sync:

- `POST /sync` returns **409** while a sync is running
- `GET /` exposes `sync_in_progress`
- the dashboard shows a disabled "Sync in progress…" button and a `<meta http-equiv="refresh">` until the run finishes

Version bumped to 1.1.0 and the README updated.

## Verification

The repo has no test suite, so the feature was verified end-to-end with a throwaway script driving the app through `TestClient` with the Google credentials and the sync work stubbed out — 25 checks, all passing:

- retry button hidden on a successful report, on a missing report, and while a sync runs
- retry re-runs **only** the failed provider, over the stored date range
- old-format report renders and falls back to the `SYNC_DAYS_OFFSET` range
- `POST /sync` → 409 and a second `/sync/retry` → `/?sync_busy=1` while a sync runs
- the lock is released even when the sync raises
- merge keeps the provider that was not re-run, overwrites the retried one, and recomputes the overall status in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)