### PR TITLE
Fix Eni provider sync failures

### DIFF
--- a/bolletta_sync/providers/eni.py
+++ b/bolletta_sync/providers/eni.py
@@ -2,10 +2,18 @@ import os
 from datetime import date, datetime
 
 import requests
-from playwright.async_api import Page
+from playwright.async_api import Page, TimeoutError as PlaywrightTimeoutError
 from playwright_recaptcha import recaptchav2
+from playwright_recaptcha.errors import RecaptchaNotFoundError
 
 from bolletta_sync.providers.base_provider import BaseProvider, Invoice
+
+# The login page is loaded without the trailing slash: eniplenitude.com/my-eni/ answers with a
+# 301 to eniplenitude.com/my-eni, and the redirect makes playwright abort the navigation.
+LOGIN_URL = "https://eniplenitude.com/my-eni"
+# The page keeps loading trackers well past the point where the login form is usable, so the
+# "load" event is unreliable and the default 30s timeout is too tight for the recaptcha widget.
+NAVIGATION_TIMEOUT = 60_000
 
 
 class Eni(BaseProvider):
@@ -14,17 +22,31 @@ class Eni(BaseProvider):
         self.account_code = None
 
     async def _login_eni(self):
-        await self.page.goto("https://eniplenitude.com/my-eni/")
+        self.page.set_default_timeout(NAVIGATION_TIMEOUT)
+        await self.page.goto(LOGIN_URL, wait_until="domcontentloaded", timeout=NAVIGATION_TIMEOUT)
 
         async with recaptchav2.AsyncSolver(self.page, capsolver_api_key=os.getenv("CAPSOLVER_API_KEY")) as solver:
-            await self.page.get_by_role("button", name="Accept proposed privacy").click()
-            await self.page.get_by_role("textbox", name="email").fill(os.getenv("ENI_USERNAME"))  # pyright: ignore[reportArgumentType]
-            await solver.solve_recaptcha(wait=True, image_challenge=True)
+            # The privacy banner is only shown until the consent cookie is set.
+            try:
+                await self.page.get_by_role("button", name="Accept proposed privacy").click(timeout=10_000)
+            except PlaywrightTimeoutError:
+                self.logger.info("privacy banner not shown, skipping")
+
+            email = self.page.get_by_role("textbox", name="email")
+            await email.wait_for(state="visible")
+            await email.fill(os.getenv("ENI_USERNAME"))  # pyright: ignore[reportArgumentType]
+
+            # Eni serves the challenge based on risk, so it is not always there.
+            try:
+                await solver.solve_recaptcha(wait=True, image_challenge=True)
+            except RecaptchaNotFoundError:
+                self.logger.info("no recaptcha challenge, skipping")
+
             await self.page.get_by_role("button", name="Prosegui", exact=True).click()
 
             await self.page.get_by_role("textbox", name="password").fill(os.getenv("ENI_PASSWORD"))  # pyright: ignore[reportArgumentType]
 
-        async with self.page.expect_navigation():
+        async with self.page.expect_navigation(wait_until="domcontentloaded", timeout=NAVIGATION_TIMEOUT):
             await self.page.get_by_role("button", name="Accedi").click()
 
     async def get_invoices(self, start_date: date, end_date: date) -> list[Invoice]:

--- a/bolletta_sync/sync.py
+++ b/bolletta_sync/sync.py
@@ -152,6 +152,12 @@ class Sync:
                     )
                     await asyncio.sleep(wait_seconds)
 
+                    # Start the retry from a clean browser context: cookies, consent banners
+                    # and leftover frames from the failed attempt would otherwise make every
+                    # retry fail the same way.
+                    await instance.page.close()
+                    instance.page = await browser.new_page(locale="en-EN")
+
                 try:
                     logger.info(f"{provider.value} - Fetching invoices (attempt {attempt}/{self._max_retries + 1})")
                     invoices = await instance.get_invoices(self._date_range[0], self._date_range[1])
@@ -176,7 +182,7 @@ class Sync:
             logger.error(f"{provider.value} - Error while syncing: {e}")
             raise e
         finally:
-            await page.close()
+            await instance.page.close()
 
     def _save_last_sync(self, results: Dict[str, Any]) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bolletta-sync"
-version = "1.1.0"
+version = "1.1.1"
 description = ""
 authors = [
     {name = "Gabriele Sorci", email = "gabrielesorci.25@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "bolletta-sync"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Problem

The `eni` provider exhausted all 4 attempts on every run. Pod logs (`bolletta-sync` namespace) show the same shape across three consecutive runs — the nightly cron plus two manual dashboard retries:

```
attempt 1/4: AsyncSolver.solve_recaptcha: Timeout 30000ms  (.rc-imageselect-tile, "element was detached from the DOM")
attempt 2/4: Page.goto: Timeout 30000ms  navigating to ".../my-eni/", waiting until "load"
attempt 3/4: Page.goto: Timeout 30000ms  ...or "Navigation to .../my-eni/ is interrupted by another navigation to .../my-eni"
attempt 4/4: Locator.click: Timeout 30000ms  waiting for get_by_role("button", name="Accept proposed privacy")
             The reCAPTCHA was not found.
```

Attempt 1 fails randomly on the recaptcha; attempts 2-4 fail **deterministically**, before reaching it. That is not flakiness — it is state leaking between attempts.

## Root causes

**1. Retries reused the same page.** `_exec_sync` created the page once, outside the retry loop. `browser.new_page()` opens an implicit browser context, so consent cookies, partial session and leftover recaptcha frames survived into the next attempt — which is what made every retry fail identically. Direct evidence in the logs: by attempt 4 the privacy banner no longer appears (cookie already set) and the click burns a 30s timeout.

**2. `page.goto` waited for `load`.** eniplenitude.com keeps loading trackers long after the login form is usable, so the DOM is ready but `load` never fires within 30s.

**3. Trailing-slash redirect race.** `https://eniplenitude.com/my-eni/` returns a **301** to `https://eniplenitude.com/my-eni`, and playwright reports the navigation as interrupted.

**4. Privacy banner and recaptcha treated as always present.** Neither is: the banner only shows until the consent cookie is set, and eni serves the challenge based on risk. When absent, each burned 30s and failed the attempt.

## Changes

- `sync.py` — each retry gets a fresh page, so attempts are actually independent. Benefits every provider (`fastweb` fails in the logs for a related reason), though only `eni` is touched otherwise.
- `eni.py` — canonical URL without trailing slash; `wait_until="domcontentloaded"` with a 60s timeout (which also gives the recaptcha widget room to settle after a re-render); optional privacy banner; `RecaptchaNotFoundError` tolerated; same `domcontentloaded` treatment for the post-login navigation.
- `pyproject.toml` — 1.1.0 → 1.1.1.

`image_challenge=True` with CapSolver is kept: the audio challenge needs ffmpeg, which is not in the image.

## Verification

The repo has no test infrastructure and an automated test would mean mocking Playwright against a third-party site, so this was verified with real end-to-end runs against eni (date range with no invoices, so no Drive/Tasks writes):

- **Run 1** — attempt 1 failed on the recaptcha (`The reCAPTCHA could not be solved.`), **attempt 2 succeeded**. Previously attempts 2-4 always died at `Page.goto`. The retry also re-encountered the privacy banner, confirming the fresh context.
- **Run 2** — succeeded on attempt 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)